### PR TITLE
Fix bug that breaks reactivity when changing graph colors, and refactor methods to mutate widget objects directly instead of via ID

### DIFF
--- a/frontend/src/components/widgets/Widget.vue
+++ b/frontend/src/components/widgets/Widget.vue
@@ -9,8 +9,8 @@ import type { Widget } from '@/utils/widgetData'
 // also, we might want to do some sort of useWidgetInject or something... or make another wrapper around widgets that provides.. or provide here... idk.
 const widget = inject<Widget>('widget')!
 
-const { start: dragStart, isDragging } = useWidgetDrag(widget.id)
-const { start: resizeStart, isResizing } = useWidgetResize(widget.id)
+const { start: dragStart, isDragging } = useWidgetDrag(widget)
+const { start: resizeStart, isResizing } = useWidgetResize(widget)
 
 const styles = useWidgetStyles(widget)
 const classes = computed(() => {

--- a/frontend/src/components/widgets/expression/ExpressionToolbar.vue
+++ b/frontend/src/components/widgets/expression/ExpressionToolbar.vue
@@ -18,7 +18,7 @@ function convertToGraph(){
 const { copy, copyUIOpen } = useCopyTextWithUI(expression.latex)
 </script>
 <template>
-	<WidgetToolbar @close="widgetStore.deleteWidget(expression.id)">
+	<WidgetToolbar @close="widgetStore.deleteWidget(expression)">
 		<template #title> Expression </template>
 		<template #content>
 			<WidgetToolbarButton @pointerup="convertToGraph()">

--- a/frontend/src/components/widgets/graph/Graph.vue
+++ b/frontend/src/components/widgets/graph/Graph.vue
@@ -18,7 +18,7 @@ provide('widget', widget) // hmm this is repeat code and doesen't cause an error
 <template>
 	<Widget>
 		<template #toolbar>
-			<WidgetToolbar @close="widgetStore.deleteWidget(id)">
+			<WidgetToolbar @close="widgetStore.deleteWidget(widget)">
 				<template #title> Graph </template>
 			</WidgetToolbar>
 		</template>

--- a/frontend/src/components/widgets/graph/GraphBottomBar.vue
+++ b/frontend/src/components/widgets/graph/GraphBottomBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useWidgetStore } from '@/stores/useWidgetStore'
-import { GraphData } from '@/utils/widgetData'
+import { ExpressionData, GraphData } from '@/utils/widgetData'
 import GraphBottomBarExpression from './GraphBottomBarExpression.vue'
 
 const props = defineProps<{
@@ -9,8 +9,8 @@ const props = defineProps<{
 const widgetStore = useWidgetStore()
 const widget = widgetStore.getWidgetById(props.id) as GraphData
 
-function changeColor(expressionId: string, color: string) {
-	widget.changeGraphColor(expressionId, color)
+function changeColor(expression: ExpressionData, color: string) {
+	widget.changeGraphColor(expression, color)
 }
 </script>
 <template>
@@ -18,7 +18,7 @@ function changeColor(expressionId: string, color: string) {
 		<div class="expression-container" v-for="expression in widget.expressions" :key="expression.id">
 			<GraphBottomBarExpression
 				:expression="expression"
-				@changeColor="(expression, color) => changeColor(expression.id, color)"
+				@changeColor="(expression, color) => changeColor(expression, color)"
 				@convertToExpressionWidget="(expression) => widget.exportExpression(expression)"
 				@deleteExpression="(expression) => widget.deleteExpression(expression)"
 			></GraphBottomBarExpression>

--- a/frontend/src/components/widgets/graph/GraphBottomBar.vue
+++ b/frontend/src/components/widgets/graph/GraphBottomBar.vue
@@ -19,8 +19,8 @@ function changeColor(expressionId: string, color: string) {
 			<GraphBottomBarExpression
 				:expression="expression"
 				@changeColor="(expression, color) => changeColor(expression.id, color)"
-				@convertToExpressionWidget="(expression) => widget.exportExpression(expression.id)"
-				@deleteExpression="(expression) => widget.deleteExpression(expression.id)"
+				@convertToExpressionWidget="(expression) => widget.exportExpression(expression)"
+				@deleteExpression="(expression) => widget.deleteExpression(expression)"
 			></GraphBottomBarExpression>
 		</div>
 	</div>

--- a/frontend/src/composables/useDraggables.ts
+++ b/frontend/src/composables/useDraggables.ts
@@ -112,7 +112,7 @@ export function useWidgetDrag(id: string) {
 			// compute what actions actually happend
 			const actionGroup = new ActionGroup([])
 			if (moved) {
-				actionGroup.push(new MoveWidgetAction(id, to, from))
+				actionGroup.push(new MoveWidgetAction(widget, to, from))
 			}
 			if (zIndexChanged) {
 				actionGroup.push(new ChangeZIndexAction(widget, newZIndex, startZIndex))

--- a/frontend/src/composables/useDraggables.ts
+++ b/frontend/src/composables/useDraggables.ts
@@ -166,7 +166,7 @@ export function useWidgetResize(id: string) {
 			// compute what actions actually happend
 			const actionGroup = new ActionGroup([])
 			if (resized) {
-				actionGroup.push(new ResizeWidgetAction(id, fromSize, toSize))
+				actionGroup.push(new ResizeWidgetAction(widget, fromSize, toSize))
 			}
 			if (zIndexChanged) {
 				actionGroup.push(new ChangeZIndexAction(widget, newZIndex, startZIndex))

--- a/frontend/src/composables/useDraggables.ts
+++ b/frontend/src/composables/useDraggables.ts
@@ -124,7 +124,7 @@ export function useWidgetDrag(id: string) {
 				const graph = widgets.find((widget) => widget instanceof GraphData)
 
 				if (graph) {
-					const action = new ImportExpressionToGraphAction(graph, id)
+					const action = new ImportExpressionToGraphAction(graph, widget)
 					action.do()
 					actionGroup.push(action)
 				}

--- a/frontend/src/composables/useDraggables.ts
+++ b/frontend/src/composables/useDraggables.ts
@@ -12,7 +12,7 @@ import {
 	ResizeWidgetAction,
 } from '@/utils/actions'
 import { useSessionStore } from '@/stores/useSessionStore'
-import { ExpressionData, GraphData } from '@/utils/widgetData'
+import { ExpressionData, GraphData, type Widget } from '@/utils/widgetData'
 
 // PS eventually thsi may need to track pointerID for multi touch in the future PS
 // Description: computes a dx and dy for a pointer gesture, giving lifecycle hooks for it's movement
@@ -89,10 +89,9 @@ export function usePointerGestureCoordinateOffset(
 	return { start, isActive }
 }
 
-export function useWidgetDrag(id: string) {
+export function useWidgetDrag(widget: Widget) {
 	const widgetStore = useWidgetStore()
 	const sessionStore = useSessionStore()
-	const widget = widgetStore.getWidgetById(id)
 	const x = toRef(widget, 'x')
 	const y = toRef(widget, 'y')
 
@@ -101,7 +100,7 @@ export function useWidgetDrag(id: string) {
 
 	const { start, isActive: isDragging } = usePointerGestureCoordinateOffset(x, y, {
 		onDown: () => {
-			sessionStore.heldWidgetId = id
+			sessionStore.heldWidgetId = widget.id
 			startZIndex = widget.zIndex
 			newZIndex = widgetStore.bringWidgetToFrontSilently(widget)
 		},
@@ -142,9 +141,8 @@ export function useWidgetDrag(id: string) {
 	return { start, isDragging }
 }
 
-export function useWidgetResize(id: string) {
+export function useWidgetResize(widget: Widget) {
 	const widgetStore = useWidgetStore()
-	const widget = widgetStore.getWidgetById(id)
 	const width = toRef(widget, 'width')
 	const height = toRef(widget, 'height')
 

--- a/frontend/src/stores/useWidgetStore.ts
+++ b/frontend/src/stores/useWidgetStore.ts
@@ -14,8 +14,8 @@ export const useWidgetStore = defineStore('widgets', () => {
 	const widgets = ref<Widget[]>([])
 	const zIndexCount = ref<number>(2)
 
-	function addWidget(widgetData: Widget) {
-		executeAction(new AddWidgetAction(widgetData))
+	function addWidget(widget: Widget) {
+		executeAction(new AddWidgetAction(widget))
 	}
 	function getWidgetById(id: string): Widget {
 		const widget = widgets.value.find((e) => e.id === id)
@@ -29,15 +29,12 @@ export const useWidgetStore = defineStore('widgets', () => {
 		return widget
 	}
 
-	function getCollidingWidgets(widgetId: string): Widget[] {
-		const target = getWidgetById(widgetId)
-		if (!target) return []
-
+	function getCollidingWidgets(widget: Widget): Widget[] {
 		return widgets.value.filter((other): other is Widget => {
-			if (other.id === widgetId) return false
+			if (other.id === widget.id) return false
 
-			const overlapX = target.x < other.x + other.width && target.x + target.width > other.x
-			const overlapY = target.y < other.y + other.height && target.y + target.height > other.y
+			const overlapX = widget.x < other.x + other.width && widget.x + widget.width > other.x
+			const overlapY = widget.y < other.y + other.height && widget.y + widget.height > other.y
 
 			return overlapX && overlapY
 		})
@@ -66,8 +63,8 @@ export const useWidgetStore = defineStore('widgets', () => {
 		return widgets
 	}
 
-	function deleteWidget(id: string) {
-		executeAction(new RemoveWidgetAction(getWidgetById(id)))
+	function deleteWidget(widget: Widget) {
+		executeAction(new RemoveWidgetAction(widget))
 	}
 
 	function bringWidgetToFrontSilently(widget: Widget) {

--- a/frontend/src/utils/actions.ts
+++ b/frontend/src/utils/actions.ts
@@ -108,22 +108,18 @@ export class MoveWidgetAction implements Action {
 // this also shouldn't require a "from" parameter
 export class ResizeWidgetAction implements Action {
 	constructor(
-		private id: string,
+		private widget: Widget,
 		private from: Size, // eventually if we implement non-bottom-right resizing these will be Rect objects
 		private to: Size,
 	) {}
 
 	do() {
-		const widgetStore = useWidgetStore()
-		const widget = widgetStore.getWidgetById(this.id)
-		widget.width = this.to.width
-		widget.height = this.to.height
+		this.widget.width = this.to.width
+		this.widget.height = this.to.height
 	}
 	undo() {
-		const widgetStore = useWidgetStore()
-		const widget = widgetStore.getWidgetById(this.id)
-		widget.width = this.from.width
-		widget.height = this.from.height
+		this.widget.width = this.from.width
+		this.widget.height = this.from.height
 	}
 }
 

--- a/frontend/src/utils/actions.ts
+++ b/frontend/src/utils/actions.ts
@@ -265,21 +265,19 @@ export class ChangeGraphColorAction extends EditWidgetAction<ExpressionData> {
 
 // this does NOT delete the expression, just adds it.
 export class AddExpressionToGraphAction extends EditWidgetAction<GraphData> {
-	constructor(graph: GraphData, expressionId: string) {
+	constructor(graph: GraphData, expression: ExpressionData) {
 		// mutate graphData with new expression..
-		const expression = useWidgetStore().getWidgetById(expressionId) as ExpressionData
 		const newExpressions = [expression, ...graph.expressions]
 
 		super(graph, { expressions: newExpressions }, (graph) => {
-			graph.syncExpression(expressionId)
+			graph.syncExpression(expression.id)
 		})
 	}
 }
 
 export class ImportExpressionToGraphAction extends ActionGroup {
-	constructor(graph: GraphData, expressionId: string) {
-		const addExpressionAction = new AddExpressionToGraphAction(graph, expressionId)
-		const expression = useWidgetStore().getWidgetById(expressionId)
+	constructor(graph: GraphData, expression: ExpressionData) {
+		const addExpressionAction = new AddExpressionToGraphAction(graph, expression)
 		const deleteWidgetAction = new RemoveWidgetAction(expression)
 
 		super([addExpressionAction, deleteWidgetAction])

--- a/frontend/src/utils/actions.ts
+++ b/frontend/src/utils/actions.ts
@@ -187,7 +187,7 @@ export function isWidgetCovered(widget: Widget, zIndex?: number) {
 	const testZIndex = zIndex ?? widget.zIndex
 
 	if (testZIndex == widgetStore.zIndexCount) return false
-	if (!widgetStore.getCollidingWidgets(widget.id).some((other) => other.zIndex > testZIndex)) return false
+	if (!widgetStore.getCollidingWidgets(widget).some((other) => other.zIndex > testZIndex)) return false
 
 	return true
 }

--- a/frontend/src/utils/actions.ts
+++ b/frontend/src/utils/actions.ts
@@ -256,7 +256,6 @@ export class ChangeGraphColorAction extends EditWidgetAction<ExpressionData> {
 		const expression = graph.expressions.find((e) => e.id == expressionId)
 		if (!expression) throw new Error("the graph doesen't have this expression")
 
-
 		super(expression, { graphColor: newColor }, () => {
 			graph.syncExpression(expressionId)
 		})
@@ -285,16 +284,16 @@ export class ImportExpressionToGraphAction extends ActionGroup {
 }
 
 export class RemoveExpressionFromGraphAction extends ActionGroup {
-	constructor(graph: GraphData, expressionId: string) {
+	constructor(graph: GraphData, expression: ExpressionData) {
 		const actions: Action[] = []
 
 		// get the new expressions list
-		const newExpressions = graph.expressions.filter((expression) => expression.id != expressionId)
+		const newExpressions = graph.expressions.filter((e) => e.id != expression.id)
 
 		// update the graph's expressions
 		actions.push(
 			new EditWidgetAction<GraphData>(graph, { expressions: newExpressions }, (graph) => {
-				graph.syncExpression(expressionId)
+				graph.syncExpression(expression.id)
 			}),
 		)
 
@@ -308,10 +307,9 @@ export class RemoveExpressionFromGraphAction extends ActionGroup {
 }
 
 export class ExportExpressionFromGraphAction extends ActionGroup {
-	constructor(graph: GraphData, expressionId: string, newExpressionPosition: Position) {
-		const expression = graph.expressions.find((expression) => expression.id == expressionId)
+	constructor(graph: GraphData, expression: ExpressionData, newExpressionPosition: Position) {
 		if (!expression) throw new Error('expression not found when removing from graph')
-		const removeExpressionFromGraphAction = new RemoveExpressionFromGraphAction(graph, expressionId)
+		const removeExpressionFromGraphAction = new RemoveExpressionFromGraphAction(graph, expression)
 
 		const addExpressionAction = new AddWidgetAction(expression)
 		const moveExpressionAction = new MoveWidgetAction(expression, newExpressionPosition, {

--- a/frontend/src/utils/actions.ts
+++ b/frontend/src/utils/actions.ts
@@ -168,29 +168,23 @@ export class EditWidgetAction<T extends Widget> implements Action {
 	private before: Partial<T> = {}
 
 	constructor(
-		private id: string,
+		private widget: T,
 		private edits: Partial<T>,
 		private afterUpdate?: (widget: T) => void,
 	) {
-		const widget = useWidgetStore().getWidgetById(this.id) as T
-
 		for (const key in edits) {
 			const k = key as keyof T
-			this.before[k] = widget[k] // could cause errors if widget[k] changes
+			this.before[k] = this.widget[k] // could cause errors if widget[k] changes
 		}
 	}
 	do() {
-		const widgetStore = useWidgetStore()
-		const widget = widgetStore.getWidgetById(this.id) as T
-		Object.assign(widget, this.edits) // object.assign preserves reactivity
-		this.afterUpdate?.(widget)
+		Object.assign(this.widget, this.edits) // object.assign preserves reactivity
+		this.afterUpdate?.(this.widget)
 	}
 
 	undo() {
-		const widgetStore = useWidgetStore()
-		const widget = widgetStore.getWidgetById(this.id) as T
-		Object.assign(widget, this.before) // object.assign preserves reactivity
-		this.afterUpdate?.(widget)
+		Object.assign(this.widget, this.before) // object.assign preserves reactivity
+		this.afterUpdate?.(this.widget)
 	}
 }
 // ================================
@@ -265,17 +259,13 @@ export class ConvertExpressionToGraphAction extends ActionGroup {
 //     GRAPHS
 // ================================
 // we could also just move this logic to GraphData instead of it's own action class
-export class ChangeGraphColorAction extends EditWidgetAction<GraphData> {
+export class ChangeGraphColorAction extends EditWidgetAction<ExpressionData> {
 	constructor(graph: GraphData, expressionId: string, newColor: string) {
-		const newExpressions = graph.expressions.map((expression) => {
-			if (expression.id != expressionId) return expression
-			return {
-				...expression,
-				graphColor: newColor,
-			}
-		}) as ExpressionData[]
+		const expression = graph.expressions.find((e) => e.id == expressionId)
+		if (!expression) throw new Error("the graph doesen't have this expression")
 
-		super(graph.id, { expressions: newExpressions }, (graph) => {
+
+		super(expression, { graphColor: newColor }, () => {
 			graph.syncExpression(expressionId)
 		})
 	}
@@ -288,7 +278,7 @@ export class AddExpressionToGraphAction extends EditWidgetAction<GraphData> {
 		const expression = useWidgetStore().getWidgetById(expressionId) as ExpressionData
 		const newExpressions = [expression, ...graph.expressions]
 
-		super(graph.id, { expressions: newExpressions }, (graph) => {
+		super(graph, { expressions: newExpressions }, (graph) => {
 			graph.syncExpression(expressionId)
 		})
 	}
@@ -313,7 +303,7 @@ export class RemoveExpressionFromGraphAction extends ActionGroup {
 
 		// update the graph's expressions
 		actions.push(
-			new EditWidgetAction<GraphData>(graph.id, { expressions: newExpressions }, (graph) => {
+			new EditWidgetAction<GraphData>(graph, { expressions: newExpressions }, (graph) => {
 				graph.syncExpression(expressionId)
 			}),
 		)

--- a/frontend/src/utils/actions.ts
+++ b/frontend/src/utils/actions.ts
@@ -252,12 +252,9 @@ export class ConvertExpressionToGraphAction extends ActionGroup {
 // ================================
 // we could also just move this logic to GraphData instead of it's own action class
 export class ChangeGraphColorAction extends EditWidgetAction<ExpressionData> {
-	constructor(graph: GraphData, expressionId: string, newColor: string) {
-		const expression = graph.expressions.find((e) => e.id == expressionId)
-		if (!expression) throw new Error("the graph doesen't have this expression")
-
+	constructor(graph: GraphData, expression: ExpressionData, newColor: string) {
 		super(expression, { graphColor: newColor }, () => {
-			graph.syncExpression(expressionId)
+			graph.syncExpression(expression)
 		})
 	}
 }
@@ -269,7 +266,7 @@ export class AddExpressionToGraphAction extends EditWidgetAction<GraphData> {
 		const newExpressions = [expression, ...graph.expressions]
 
 		super(graph, { expressions: newExpressions }, (graph) => {
-			graph.syncExpression(expression.id)
+			graph.syncExpression(expression)
 		})
 	}
 }
@@ -293,7 +290,7 @@ export class RemoveExpressionFromGraphAction extends ActionGroup {
 		// update the graph's expressions
 		actions.push(
 			new EditWidgetAction<GraphData>(graph, { expressions: newExpressions }, (graph) => {
-				graph.syncExpression(expression.id)
+				graph.syncExpression(expression)
 			}),
 		)
 

--- a/frontend/src/utils/actions.ts
+++ b/frontend/src/utils/actions.ts
@@ -91,22 +91,18 @@ export class RecognizeCanvasAction extends ActionGroup {
 // ================================
 export class MoveWidgetAction implements Action {
 	constructor(
-		private id: string,
+		private widget: Widget,
 		private to: Position,
 		private from: Position, // TODO we could make this optional if wanted
 	) {}
 
 	do() {
-		const widgetStore = useWidgetStore()
-		const widget = widgetStore.getWidgetById(this.id)
-		widget.x = this.to.x
-		widget.y = this.to.y
+		this.widget.x = this.to.x
+		this.widget.y = this.to.y
 	}
 	undo() {
-		const widgetStore = useWidgetStore()
-		const widget = widgetStore.getWidgetById(this.id)
-		widget.x = this.from.x
-		widget.y = this.from.y
+		this.widget.x = this.from.x
+		this.widget.y = this.from.y
 	}
 }
 // this also shouldn't require a "from" parameter
@@ -324,7 +320,7 @@ export class ExportExpressionFromGraphAction extends ActionGroup {
 		const removeExpressionFromGraphAction = new RemoveExpressionFromGraphAction(graph, expressionId)
 
 		const addExpressionAction = new AddWidgetAction(expression)
-		const moveExpressionAction = new MoveWidgetAction(expression.id, newExpressionPosition, {
+		const moveExpressionAction = new MoveWidgetAction(expression, newExpressionPosition, {
 			x: expression.x,
 			y: expression.y,
 		})

--- a/frontend/src/utils/widgetData.ts
+++ b/frontend/src/utils/widgetData.ts
@@ -116,35 +116,33 @@ export class GraphData extends WidgetData {
 		const action = new RemoveExpressionFromGraphAction(this, expression)
 		executeAction(action)
 	}
-	changeGraphColor(expressionId: string, color: string) {
-		const action = new ChangeGraphColorAction(this, expressionId, color)
+	changeGraphColor(expression: ExpressionData, color: string) {
+		const action = new ChangeGraphColorAction(this, expression, color)
 		executeAction(action)
 	}
-	async syncExpression(expressionId: string) {
+	async syncExpression(expression: ExpressionData) {
 		// if the expression is in the calculator but not the list, remove it from calculator
 		if (
 			this.calculator
 				.getExpressions()
-				.map((expression) => expression.id)
-				.includes(expressionId) &&
-			!this.expressions.map((expression) => expression.id).includes(expressionId)
+				.map((e) => e.id)
+				.includes(expression.id) &&
+			!this.expressions.map((e) => e.id).includes(expression.id)
 		) {
-			this.calculator.removeExpression({ id: expressionId })
+			this.calculator.removeExpression({ id: expression.id })
 			return
 		}
 
 		// otherwise, add/exit the expression
-		const expression = this.expressions.find((expression) => expression.id == expressionId)
-		if (!expression) throw new Error("This expression doesen't exist")
 		this.calculator.setExpression({
-			id: expressionId,
+			id: expression.id,
 			latex: await expression.latex,
 			color: expression.graphColor,
 		})
 	}
 	syncAllExpressions() {
 		for (let expression of this.expressions) {
-			this.syncExpression(expression.id)
+			this.syncExpression(expression)
 		}
 	}
 	copyExpression(expression: ExpressionData) {

--- a/frontend/src/utils/widgetData.ts
+++ b/frontend/src/utils/widgetData.ts
@@ -98,7 +98,7 @@ export class GraphData extends WidgetData {
 		this.type = 'Graph'
 		this.expressions = [...expressions]
 	}
-	exportExpression(expressionId: string) {
+	exportExpression(expression: ExpressionData) {
 		// calculate expression position
 		let position = { x: 0, y: 0 }
 		position.x = this.x
@@ -109,11 +109,11 @@ export class GraphData extends WidgetData {
 			position.y = this.y
 		}
 
-		const action = new ExportExpressionFromGraphAction(this, expressionId, position)
+		const action = new ExportExpressionFromGraphAction(this, expression, position)
 		executeAction(action)
 	}
-	deleteExpression(expressionId: string) {
-		const action = new RemoveExpressionFromGraphAction(this, expressionId)
+	deleteExpression(expression: ExpressionData) {
+		const action = new RemoveExpressionFromGraphAction(this, expression)
 		executeAction(action)
 	}
 	changeGraphColor(expressionId: string, color: string) {


### PR DESCRIPTION
**This PR does two things that are related:**
1) Fixes a bug that broke reactivity when changing the color of an expression on a graph. This was happening because we were reassigning the expression completely, and so removing it from the graph would delete it.
2) Refactors methods that mutate a widget like `useWidgetDrag`, `changeGraphColorAction`, etc. to mutate the objects directly instead of referencing the widget's ID against the array it's in. 
^ this is better because it doesn't waste memory to pass around objects since it's by reference, and it guarantees reactivity without having to find the widget. 